### PR TITLE
Add mob management function and help message

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,9 +33,9 @@ jobs:
         sudo make install install-info
     - name: Show git version
       run: git version
-    - name: Use Go 1.20.x
+    - name: Use Go 1.22.x
       uses: actions/setup-go@v4
       with:
-        go-version: '~1.20'
+        go-version: '~1.22'
     - name: Test
       run: go test -test.v

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,10 +17,10 @@ jobs:
       sha_linux: ${{ steps.shasum.outputs.sha_linux }}
     steps:
       - uses: actions/checkout@main
-      - name: Use Go 1.20.x
+      - name: Use Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: '~1.20'
+          go-version: '~1.22'
       - name: Test
         run: go test
         env:

--- a/.github/workflows/virustotal.yaml
+++ b/.github/workflows/virustotal.yaml
@@ -13,7 +13,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '~1.20'
+          go-version: '~1.22'
       -
         name: Build
         run: |

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ sudo snap connect mob-sh:ssh-keys
 
 ### Using go tools
 
-If you have go 1.20+ you can install and build directly from source:
+If you have go 1.22+ you can install and build directly from source:
 
 ```bash
 go install github.com/remotemobprogramming/mob/v4@latest

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/remotemobprogramming/mob/v4
 
-go 1.20
+go 1.22.1

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/remotemobprogramming/mob/v4
 
-go 1.22.1
+go 1.22

--- a/help/help.go
+++ b/help/help.go
@@ -38,8 +38,8 @@ Timer Commands:
   break <minutes>    Start <minutes> break timer
 
 Mob Management Commands:
-  mobbers <add | include | +> <...names>        Add names to participant list
-  mobbers <remove | exclude | -> <...names>     Remove names from participant list
+  manage <add | include | +> <...names>         Add names to participant list
+  manage <remove | exclude | -> <...names>      Remove names from participant list
 
 Short Commands (Options and descriptions as above):
   s                  Alias for 'start'

--- a/help/help.go
+++ b/help/help.go
@@ -37,6 +37,10 @@ Timer Commands:
   start <minutes>    Start mob session in wip branch and a <minutes> timer
   break <minutes>    Start <minutes> break timer
 
+Mob Management Commands:
+  mobbers <add | include | +> <...names>        Add names to participant list
+  mobbers <remove | exclude | -> <...names>     Remove names from participant list
+
 Short Commands (Options and descriptions as above):
   s                  Alias for 'start'
   n                  Alias for 'next'

--- a/manage/manage.go
+++ b/manage/manage.go
@@ -1,0 +1,109 @@
+package manage
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+)
+
+const fileName = "participants.txt"
+
+func AddParticipants(participants []string) {
+	existing := readParticipants()
+
+	existingMap := make(map[string]bool)
+	for _, participant := range existing {
+		existingMap[participant] = true
+	}
+
+	file, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Println("Error opening file:", err)
+		return
+	}
+	defer file.Close()
+
+	for _, newParticipant := range participants {
+		if _, exists := existingMap[newParticipant]; !exists {
+			if _, err := file.WriteString(newParticipant + "\n"); err != nil {
+				fmt.Println("Error writing to file:", err)
+				return
+			}
+		}
+	}
+}
+
+func RemoveParticipants(participants []string) {
+	contents, err := os.ReadFile(fileName)
+	if err != nil {
+		fmt.Println("Error reading file:", err)
+		return
+	}
+
+	lines := strings.Split(string(contents), "\n")
+	var newLines []string
+
+	for _, line := range lines {
+		if line != "" && !slices.Contains(participants, line) {
+			newLines = append(newLines, line)
+		}
+	}
+
+	newContent := strings.Join(newLines, "\n")
+	newContent = strings.TrimSpace(newContent) + "\n"
+
+	err = os.WriteFile(fileName, []byte(newContent), 0644)
+	if err != nil {
+		fmt.Println("Error writing file:", err)
+	}
+}
+
+func DisplayNextTypist(currentTypist string) {
+	participants := readParticipants()
+
+	if len(participants) == 0 {
+		fmt.Println("No participants found.")
+		return
+	}
+
+	nextTypist, err := getNextTypist(currentTypist, participants)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	fmt.Println("Next typist:", nextTypist)
+}
+
+func readParticipants() []string {
+	file, err := os.Open(fileName)
+	if err != nil {
+		return []string{}
+	}
+	defer file.Close()
+
+	var participants []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		participants = append(participants, scanner.Text())
+	}
+	//// Closing explicitly because tests seem to get old contents
+	//file.Close()
+
+	return participants
+}
+
+func getNextTypist(currentTypist string, participants []string) (string, error) {
+	currentPosition := slices.Index(participants, currentTypist)
+	if currentPosition == -1 {
+		return "", errors.New("current timer user not found")
+	}
+	if currentPosition < len(participants)-1 {
+		return participants[currentPosition+1], nil
+	} else {
+		return participants[0], nil
+	}
+}

--- a/manage/manage_test.go
+++ b/manage/manage_test.go
@@ -1,0 +1,53 @@
+package manage
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestGetNextTypist(t *testing.T) {
+	tests := []struct {
+		name          string
+		currentTypist string
+		participants  []string
+		expected      string
+		expectedError error
+	}{
+		{
+			name:          "Next participant exists",
+			currentTypist: "Joe",
+			participants:  []string{"Joe", "Jane", "Jack"},
+			expected:      "Jane",
+			expectedError: nil,
+		},
+		{
+			name:          "Current participant is last, loop back",
+			currentTypist: "Jack",
+			participants:  []string{"Joe", "Jane", "Jack"},
+			expected:      "Joe",
+			expectedError: nil,
+		},
+		{
+			name:          "Current participant not found",
+			currentTypist: "Jill",
+			participants:  []string{"Joe", "Jane", "Jack"},
+			expected:      "",
+			expectedError: errors.New("current timer user not found"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := getNextTypist(tc.currentTypist, tc.participants)
+			if result != tc.expected {
+				t.Errorf("Expected %s, got %s", tc.expected, result)
+			}
+			if (err != nil && tc.expectedError == nil) || (err == nil && tc.expectedError != nil) {
+				t.Errorf("Expected error %v, got %v", tc.expectedError, err)
+			}
+			if err != nil && tc.expectedError != nil && err.Error() != tc.expectedError.Error() {
+				t.Errorf("Expected error message '%v', got '%v'", tc.expectedError.Error(), err.Error())
+			}
+		})
+	}
+}

--- a/mob.go
+++ b/mob.go
@@ -13,6 +13,7 @@ import (
 	"github.com/remotemobprogramming/mob/v4/open"
 	"github.com/remotemobprogramming/mob/v4/say"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -21,13 +22,14 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 )
 
 const (
-	versionNumber     = "4.5.0"
+	versionNumber     = "4.6.0"
 	minimumGitVersion = "2.13.0"
 )
 
@@ -351,6 +353,12 @@ func execute(command string, parameter []string, configuration config.Configurat
 	case "break":
 		if len(parameter) > 0 {
 			startBreakTimer(parameter[0], configuration)
+		} else {
+			help.Help(configuration)
+		}
+	case "mobbers":
+		if len(parameter) > 1 {
+			manageMobbers(configuration, parameter)
 		} else {
 			help.Help(configuration)
 		}
@@ -1490,4 +1498,20 @@ func startCommand(name string, args ...string) (string, error) {
 
 var exit = func(code int) {
 	os.Exit(code)
+}
+
+func manageMobbers(configuration config.Configuration, parameter []string) {
+	adding := []string{"add", "include", "+"}
+	removing := []string{"remove", "exclude", "-"}
+	if slices.Contains(adding, parameter[0]) == true {
+		for i := 1; i < len(parameter); i++ {
+			log.Println("Adding:", parameter[i])
+		}
+	} else if slices.Contains(removing, parameter[0]) == true {
+		for i := 1; i < len(parameter); i++ {
+			log.Println("Removing:", parameter[i])
+		}
+	} else {
+		help.Help(configuration)
+	}
 }

--- a/mob.go
+++ b/mob.go
@@ -10,10 +10,10 @@ import (
 	"fmt"
 	config "github.com/remotemobprogramming/mob/v4/configuration"
 	"github.com/remotemobprogramming/mob/v4/help"
+	"github.com/remotemobprogramming/mob/v4/manage"
 	"github.com/remotemobprogramming/mob/v4/open"
 	"github.com/remotemobprogramming/mob/v4/say"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -356,9 +356,9 @@ func execute(command string, parameter []string, configuration config.Configurat
 		} else {
 			help.Help(configuration)
 		}
-	case "mobbers":
+	case "manage":
 		if len(parameter) > 1 {
-			manageMobbers(configuration, parameter)
+			manageParticipants(configuration, parameter)
 		} else {
 			help.Help(configuration)
 		}
@@ -1311,6 +1311,7 @@ func showNext(configuration config.Configuration) {
 	if numberOfLines < 1 {
 		return
 	}
+	// TODO: if participants.txt exists, use it
 	nextTypist, previousCommitters := findNextTypist(lines, gitUserName)
 	if nextTypist != "" {
 		if len(previousCommitters) != 0 {
@@ -1500,17 +1501,13 @@ var exit = func(code int) {
 	os.Exit(code)
 }
 
-func manageMobbers(configuration config.Configuration, parameter []string) {
+func manageParticipants(configuration config.Configuration, parameter []string) {
 	adding := []string{"add", "include", "+"}
 	removing := []string{"remove", "exclude", "-"}
 	if slices.Contains(adding, parameter[0]) == true {
-		for i := 1; i < len(parameter); i++ {
-			log.Println("Adding:", parameter[i])
-		}
+		manage.AddParticipants(parameter[1:])
 	} else if slices.Contains(removing, parameter[0]) == true {
-		for i := 1; i < len(parameter); i++ {
-			log.Println("Removing:", parameter[i])
-		}
+		manage.RemoveParticipants(parameter[1:])
 	} else {
 		help.Help(configuration)
 	}

--- a/mob_test.go
+++ b/mob_test.go
@@ -1846,6 +1846,55 @@ func TestMobVersionWorksOutsideOfGitRepository(t *testing.T) {
 	assertOutputContains(t, output, "v"+versionNumber)
 }
 
+//func TestManageAddsParticipants(t *testing.T) {
+//	filename := "participants.txt"
+//	_, configuration := setup(t)
+//
+//	// Add Jane, Jo, and Jack
+//	initialAdd := []string{"add", "Jane", "Jo", "Jack"}
+//	manageParticipants(configuration, initialAdd)
+//	file, _ := os.Open("participants.txt")
+//	var participants []string
+//	scanner := bufio.NewScanner(file)
+//	for scanner.Scan() {
+//		participants = append(participants, scanner.Text())
+//	}
+//	expected := []string{"Jane", "Jo", "Jack"}
+//	if strings.Join(participants, ",") != strings.Join(expected, ",") {
+//		failWithFailure(t, expected, participants)
+//	}
+//	file.Close()
+//
+//	// Add Jill, don't add Jane
+//	addParticipant := []string{"add", "Jill", "Jane"}
+//	manageParticipants(configuration, addParticipant)
+//	file, _ = os.Open(filename)
+//	var newParticipants []string
+//	for scanner.Scan() {
+//		newParticipants = append(newParticipants, scanner.Text())
+//	}
+//	expected = []string{"Jane", "Jo", "Jack", "Jill"}
+//	if strings.Join(newParticipants, ",") != strings.Join(expected, ",") {
+//		failWithFailure(t, expected, newParticipants)
+//	}
+//	file.Close()
+//
+//	// Remove Jill, John should have no effect
+//	removeParticipant := []string{"remove", "Jill", "John"}
+//	manageParticipants(configuration, removeParticipant)
+//	file, _ = os.Open("participants.txt")
+//	var finalParticipants []string
+//	for scanner.Scan() {
+//		finalParticipants = append(finalParticipants, scanner.Text())
+//	}
+//	expected = []string{"Jane", "Jo", "Jack"}
+//	if strings.Join(finalParticipants, ",") != strings.Join(expected, ",") {
+//		failWithFailure(t, expected, finalParticipants)
+//	}
+//	file.Close()
+//	os.Remove(filename)
+//}
+
 func runMob(t *testing.T, workingDir string, args ...string) {
 	setWorkingDir(workingDir)
 	newArgs := append([]string{"mob"}, args...)

--- a/participants.txt
+++ b/participants.txt
@@ -1,0 +1,4 @@
+Jane
+Jo
+Jack
+Jill

--- a/participants.txt
+++ b/participants.txt
@@ -1,4 +1,0 @@
-Jane
-Jo
-Jack
-Jill


### PR DESCRIPTION
## Purpose

My team would like to be able to manage who is included in the mob more proactively than waiting for a rotation to enable find_next.go to determine who is the next typist.

## Major Changes

- [x] Add `manage` command
- [ ] Provide ability to add and remove participants and persist across mob turns
- [ ] Properly report next typist based on `config.TimerUser` and contents of management file
- [ ] Remove participant management as part of `mob done`

## Future Opportunities

I also want to add goal tracking through a similar temporary file and cli command. Maybe something like `mob goals add <some goal>`, `mob goals list`, `mob goals complete <some_id>`.

If the maintainers are willing to support a different paradigm, my team would find it very useful to track a navigator and potentially other roles from https://github.com/willemlarsen/mobprogrammingrpg.